### PR TITLE
fix buffer overflow

### DIFF
--- a/UPDATES
+++ b/UPDATES
@@ -1,7 +1,12 @@
 Changes in gseen.mod: (since v1.0.0)
 --------------------
 
+1.2.1 (2021-01-19)
+- fix buffer overflow (Michael Ortmann)
+
 1.2.0 (2020-12-15)
+- slightly changed makefile that makes it a bit easier to build outside the src
+  directory (Harekiet)
 - fixed some compiler warnings (Michael Ortmann)
 
 1.1.2 (2017-01-02)

--- a/datahandling.c
+++ b/datahandling.c
@@ -68,6 +68,8 @@ static void read_seens()
     s = buf;
     fgets(s, 511, f);
     i = strlen(buf);
+    if (!i)
+      continue;
     if (buf[i - 1] == '\n')
       buf[i - 1] = 0;
     if ((buf[0] == 0) || (buf[0] == '#'))

--- a/gseen.c
+++ b/gseen.c
@@ -18,8 +18,8 @@
 
 #define MAKING_GSEEN
 #define MODULE_NAME "gseen"
-#define MODULE_VERSION "1.2.0"
-#define MODULE_NUMVERSION 10200
+#define MODULE_VERSION "1.2.1"
+#define MODULE_NUMVERSION 10201
 #include "../module.h"
 #include "../irc.mod/irc.h"
 #include "../server.mod/server.h"


### PR DESCRIPTION
```
.load gseen
[10:04:23] tcl: builtin dcc call: *dcc:loadmod -HQ 1 gseen
.././gseen.mod/datahandling.c:71:12: runtime error: index -1 out of bounds for type 'char [512]'
=================================================================
==110275==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7ffc2ef812af at pc 0x7f3a2d06d7c2 bp 0x7ffc2ef81230 sp 0x7ffc2ef81220
READ of size 1 at 0x7ffc2ef812af thread T0
    #0 0x7f3a2d06d7c1 in read_seens .././gseen.mod/datahandling.c:71
    #1 0x7f3a2d06eea7 in gseen_start .././gseen.mod/gseen.c:318
    #2 0x560a3a9771eb in module_load /home/michael/projects/eggdrop/src/modules.c:836
    #3 0x560a3a9018f6 in cmd_loadmod /home/michael/projects/eggdrop/src/cmds.c:2717
    #4 0x560a3a9a9f59 in builtin_dcc /home/michael/projects/eggdrop/src/tclhash.c:681
    #5 0x560a3a98c9d6 in tcl_call_stringproc_cd /home/michael/projects/eggdrop/src/tcl.c:324
    #6 0x7f3a32d96c61 in TclNRRunCallbacks (/usr/lib/libtcl8.6.so+0x40c61)
    #7 0x7f3a32d98b39 in TclEvalEx (/usr/lib/libtcl8.6.so+0x42b39)
    #8 0x7f3a32d99362 in Tcl_EvalEx (/usr/lib/libtcl8.6.so+0x43362)
    #9 0x7f3a32d99386 in Tcl_Eval (/usr/lib/libtcl8.6.so+0x43386)
    #10 0x7f3a32d99970 in Tcl_VarEvalVA (/usr/lib/libtcl8.6.so+0x43970)
    #11 0x7f3a32d99a49 in Tcl_VarEval (/usr/lib/libtcl8.6.so+0x43a49)
    #12 0x560a3a9a6b90 in trigger_bind /home/michael/projects/eggdrop/src/tclhash.c:748
    #13 0x560a3a9ab8b6 in check_tcl_bind /home/michael/projects/eggdrop/src/tclhash.c:953
    #14 0x560a3a9ac01b in check_tcl_dcc /home/michael/projects/eggdrop/src/tclhash.c:985
    #15 0x560a3a933cd9 in dcc_chat /home/michael/projects/eggdrop/src/dcc.c:1052
    #16 0x560a3a960fb8 in mainloop main.c:876
    #17 0x560a3a963b41 in main main.c:1304
    #18 0x7f3a31d3d171 in __libc_start_main (/usr/lib/libc.so.6+0x28171)
    #19 0x560a3a8b330d in _start (/home/michael/eggdrop/eggdrop-1.9.0+0x20730d)

Address 0x7ffc2ef812af is located in stack of thread T0 at offset 63 in frame
    #0 0x7f3a2d06d0b2 in read_seens .././gseen.mod/datahandling.c:54

  This frame has 2 object(s):
    [32, 40) 's' (line 56)
    [64, 576) 'buf' (line 56) <== Memory access at offset 63 underflows this variable
HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork
      (longjmp and C++ exceptions *are* supported)
SUMMARY: AddressSanitizer: stack-buffer-overflow .././gseen.mod/datahandling.c:71 in read_seens
Shadow bytes around the buggy address:
  0x100005de8200: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x100005de8210: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x100005de8220: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x100005de8230: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x100005de8240: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 f1 f1
=>0x100005de8250: f1 f1 00 f2 f2[f2]00 00 00 00 00 00 00 00 00 00
  0x100005de8260: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x100005de8270: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x100005de8280: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x100005de8290: 00 00 00 00 00 00 f3 f3 f3 f3 f3 f3 f3 f3 00 00
  0x100005de82a0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==110275==ABORTING
```